### PR TITLE
added Exp() functions and updated UnaryOps.h file

### DIFF
--- a/include/UnaryOps.h
+++ b/include/UnaryOps.h
@@ -1,4 +1,8 @@
-// basic arithmetics
+#pragma once
+#include "Tensor.h"
+//=======================================//
+//========== Basic Arithmetics ==========//
+//=======================================//
 
 
 
@@ -8,7 +12,6 @@
 
 
 
-// trignometrics
 
 
 
@@ -18,7 +21,15 @@
 
 
 
-// exponentials and logarithms
+
+
+
+
+
+
+//=======================================//
+//============ Trigonometric ============//
+//=======================================//
 
 
 
@@ -28,4 +39,87 @@
 
 
 
-// data operations
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//=======================================//
+//===== exponentials and logarithms =====//
+//=======================================//
+
+// Operation type for dispatch
+enum class OpType { Exp = 0, Exp2, Cexp };
+
+// Type-erased kernel function pointer
+using KernelFn = void(*)(const void*, void*, size_t);
+
+// Kernel function templates
+template<typename T, T(*Func)(T)>
+void unary_kernel(const T* in, T* out, size_t n);
+
+// Function wrappers for exp, exp2
+float expf_wrap(float x);
+double exp_wrap(double x);
+float exp2f_wrap(float x);
+double exp2_wrap(double x);
+
+// Kernel instantiations
+void exp_float_kernel(const void* in, void* out, size_t n);
+void exp_double_kernel(const void* in, void* out, size_t n);
+void exp2_float_kernel(const void* in, void* out, size_t n);
+void exp2_double_kernel(const void* in, void* out, size_t n);
+
+// Kernel dispatch table
+constexpr size_t DTYPE_COUNT = 2; // float, double
+constexpr size_t OPTYPE_COUNT = 2; // exp, exp2
+extern const KernelFn kernel_table[OPTYPE_COUNT][DTYPE_COUNT];
+
+// Helper to map Tensor dtype to index
+size_t dtype_index(Dtype dtype);
+
+// Dispatch function
+Tensor unary_dispatch(const Tensor& input, OpType op);
+
+// User API
+Tensor exp(const Tensor& input);      // out-of-place
+Tensor exp2(const Tensor& input);     // out-of-place
+void exp_(Tensor& input);             // in-place
+void exp2_(Tensor& input);            // in-place
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+//=======================================//
+//=========== Data Operations ===========//
+//=======================================//

--- a/src/UnaryOps/exp_log.cpp
+++ b/src/UnaryOps/exp_log.cpp
@@ -1,0 +1,107 @@
+
+#include <cmath>
+#include "../include/Tensor.h"
+using namespace std;
+
+
+// ================================================================================================ //
+// ================================== Exponential functions ======================================= //
+// ================================================================================================ //
+
+// Helper kernels for exp, exp2
+template<typename T, T(*Func)(T)>
+void unary_kernel(const T* in, T* out, size_t n) {
+    for (size_t i = 0; i < n; ++i) {
+        out[i] = Func(in[i]);
+    }
+}
+
+// Function wrappers for exp, exp2
+float expf_wrap(float x) { return expf(x); }
+double exp_wrap(double x) { return exp(x); }
+float exp2f_wrap(float x) { return exp2f(x); }
+double exp2_wrap(double x) { return exp2(x); }
+
+// Type-erased kernel function pointer
+using KernelFn = void(*)(const void*, void*, size_t);
+
+// Kernel instantiations
+void exp_float_kernel(const void* in, void* out, size_t n) {
+    unary_kernel<float, expf_wrap>(static_cast<const float*>(in), static_cast<float*>(out), n);
+}
+void exp_double_kernel(const void* in, void* out, size_t n) {
+    unary_kernel<double, exp_wrap>(static_cast<const double*>(in), static_cast<double*>(out), n);
+}
+void exp2_float_kernel(const void* in, void* out, size_t n) {
+    unary_kernel<float, exp2f_wrap>(static_cast<const float*>(in), static_cast<float*>(out), n);
+}
+void exp2_double_kernel(const void* in, void* out, size_t n) {
+    unary_kernel<double, exp2_wrap>(static_cast<const double*>(in), static_cast<double*>(out), n);
+}
+
+// Table of kernels per dtype for each op
+enum class OpType { Exp = 0, Exp2 };
+
+constexpr size_t DTYPE_COUNT = 2; // float, double
+constexpr size_t OPTYPE_COUNT = 2; // exp, exp2
+
+// Dtype indices: 0=float, 1=double
+static const KernelFn kernel_table[OPTYPE_COUNT][DTYPE_COUNT] = {
+    // Exp
+    { exp_float_kernel, exp_double_kernel },
+    // Exp2
+    { exp2_float_kernel, exp2_double_kernel }
+};
+
+// Helper to map Tensor dtype to index
+size_t dtype_index(Dtype dtype) {
+    switch (dtype) {
+        case Dtype::Int16:
+        case Dtype::Int32:
+        case Dtype::Int64:
+        case Dtype::Bfloat16:
+        case Dtype::Float16:
+        case Dtype::Float32: return 0;
+        case Dtype::Float64: return 1;
+        default: throw std::runtime_error("Unsupported dtype for exp ops");
+    }
+}
+
+// Out-of-place operation: returns new tensor
+Tensor unary_dispatch(const Tensor& input, OpType op) {
+    Tensor output(Shape{input.shape()}, input.dtype(), input.device(), false);
+    size_t total_elems = input.numel();
+    size_t idx = dtype_index(input.dtype());
+    KernelFn fn = kernel_table[static_cast<size_t>(op)][idx];
+    fn(input.data(), output.data(), total_elems);
+    return output;
+}
+
+Tensor exp(const Tensor& input) {
+    return unary_dispatch(input, OpType::Exp);
+}
+
+Tensor exp2(const Tensor& input) {
+    return unary_dispatch(input, OpType::Exp2);
+}
+
+// In-place operation: modifies input tensor
+void exp_(Tensor& input) {
+    size_t total_elems = input.numel();
+    size_t idx = dtype_index(input.dtype());
+    KernelFn fn = kernel_table[static_cast<size_t>(OpType::Exp)][idx];
+    fn(input.data(), input.data(), total_elems);
+}
+
+void exp2_(Tensor& input) {
+    size_t total_elems = input.numel();
+    size_t idx = dtype_index(input.dtype());
+    KernelFn fn = kernel_table[static_cast<size_t>(OpType::Exp2)][idx];
+    fn(input.data(), input.data(), total_elems);
+}
+
+
+
+// ================================================================================================ //
+// ================================== Logarithmic functions ======================================= //
+// ================================================================================================ //


### PR DESCRIPTION
- added exponentiation function for float and double datatypes
- need to consider the cases for Bfloat16 and Float16 later
- uses kernel dispatcher to perform the correct function call
- has a view (exp_) and copy (exp) method.

Future work:
- need to optimise the code 
- need to add for non-standard datatypes.
- decide on a precision.